### PR TITLE
[FIX] Base URL provided by a user

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,15 +17,18 @@ const isProd = process.env.NODE_ENV === 'production';
  * });
 */
 class ApiRequest {
+  private _baseUrl: string;
   private _routeSchema: TRouteSchema;
   private _authToken?: string;
 
   constructor(
+    baseUrl: string,
     routeSchema: TRouteSchema,
     authToken?: string
   ) {
     this._routeSchema = routeSchema;
     this._authToken = authToken;
+    this._baseUrl = baseUrl;
   };
 
   /**
@@ -37,7 +40,8 @@ class ApiRequest {
     try {
       const requestConfig = this.prepareRequestConfig(this._routeSchema, requestPayload);
       const { baseURL, url, ...rest } = requestConfig;
-      return await fetch(baseURL + url, rest);
+      const fetchUrl = this._baseUrl ?? baseURL;
+      return await fetch(fetchUrl + url, rest);
     }
     catch (err) {
       throw new Error(


### PR DESCRIPTION
User defined bseUrl is preferable over request schema one.

Decided to make it this way, so an end client could pass the baseUrl as it's in the fetch API.

This would help to reduce extra code for defining baseUrl(s) when creating request schemas for multiple hosts.

For example, if we use this lib on the localhost and the dev/prod server, we would like to have different baseUrl(s), i.e. `localhost` and `<server_hostname>`, so with this with just define it ones and pass it to the constructor instead of managing this url in the schema file.